### PR TITLE
Fix contextlib2 import

### DIFF
--- a/fabric/context_managers.py
+++ b/fabric/context_managers.py
@@ -34,8 +34,11 @@ Context managers for use with the ``with`` statement.
 """
 
 from contextlib import contextmanager
-from contextlib2 import ExitStack
 import sys
+if sys.version_info < (3, 0):
+    from contextlib2 import ExitStack
+else:
+    from contextlib import ExitStack
 import socket
 import select
 


### PR DESCRIPTION
I've been using your awesome fork, but just noticed this remaining compatibility issue.
